### PR TITLE
fix default value of bios_attribute_list from None to []

### DIFF
--- a/examples/set_bios_password.py
+++ b/examples/set_bios_password.py
@@ -96,7 +96,7 @@ def set_bios_password(ip, login_account, login_password, system_id, bios_passwor
                     bios_registry_response = REDFISH_OBJ.get(bios_registry_url, None)
                     if bios_registry_response.status == 200:
                         bios_registry_json_url = bios_registry_response.dict["Location"][0]["Uri"]
-                bios_attribute_list = None
+                bios_attribute_list = []
                 if bios_registry_json_url != "":
                     bios_registry_json_response = REDFISH_OBJ.get(bios_registry_json_url, None)
                     if bios_registry_json_response.status == 200:


### PR DESCRIPTION
fix default value of bios_attribute_list from None to [] to avoid type error on getting bios_attribute_list fail case