### PR TITLE
Relative import of lenovo_utils so it can be used in scripts outside …

### DIFF
--- a/examples/add_event_subscriptions.py
+++ b/examples/add_event_subscriptions.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def add_event_subscriptions(ip, login_account, login_password,destination,eventtypes,context):
     """Add event subscriptions

--- a/examples/clear_sessions.py
+++ b/examples/clear_sessions.py
@@ -24,7 +24,7 @@ import sys
 import redfish
 import json
 import string
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def clear_sessions(ip, login_account, login_password, username):
     """Get BMC inventory    

--- a/examples/clear_system_log.py
+++ b/examples/clear_system_log.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def clear_system_log(ip, login_account, login_password, system_id, type):

--- a/examples/del_event_subscriptions.py
+++ b/examples/del_event_subscriptions.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def del_event_subscriptions(ip, login_account, login_password,option_command):
     """Del event subscriptions

--- a/examples/del_tasks.py
+++ b/examples/del_tasks.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def del_tasks(ip, login_account, login_password,option_command):
     """Delete all tasks or the task specified

--- a/examples/disable_bmc_user.py
+++ b/examples/disable_bmc_user.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def disable_bmc_user(ip, login_account, login_password, username):

--- a/examples/disable_secure_boot.py
+++ b/examples/disable_secure_boot.py
@@ -22,7 +22,7 @@
 
 import sys
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import json
 
 

--- a/examples/enable_bmc_user.py
+++ b/examples/enable_bmc_user.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def enable_bmc_user(ip, login_account, login_password, username):

--- a/examples/enable_secure_boot.py
+++ b/examples/enable_secure_boot.py
@@ -22,7 +22,7 @@
 
 import sys
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import json
 
 

--- a/examples/get_all_bios_attributes.py
+++ b/examples/get_all_bios_attributes.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_all_bios_attributes(ip, login_account, login_password, system_id, bios_get):

--- a/examples/get_all_tasks.py
+++ b/examples/get_all_tasks.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_all_tasks(ip, login_account, login_password):
     """Get all tasks

--- a/examples/get_bios_attribute.py
+++ b/examples/get_bios_attribute.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_bios_attribute(ip, login_account, login_password, system_id, attribute_name):

--- a/examples/get_bios_attribute_metadata.py
+++ b/examples/get_bios_attribute_metadata.py
@@ -24,7 +24,7 @@
 import sys, os
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_bios_attribute_metadata(ip, login_account, login_password, system_id):

--- a/examples/get_bios_bootmode.py
+++ b/examples/get_bios_bootmode.py
@@ -22,7 +22,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_bios_bootmode(ip, login_account, login_password, system_id):

--- a/examples/get_bmc_inventory.py
+++ b/examples/get_bmc_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_bmc_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_bmc_ntp.py
+++ b/examples/get_bmc_ntp.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_bmc_ntp(ip, login_account, login_password):
     """Get bmc ntp

--- a/examples/get_chassis_indicator_led.py
+++ b/examples/get_chassis_indicator_led.py
@@ -22,7 +22,7 @@
 import redfish
 import sys
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_chassis_indicator_led(ip, login_account, login_password):

--- a/examples/get_cpu_inventory.py
+++ b/examples/get_cpu_inventory.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_cpu_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_event_subscriptions.py
+++ b/examples/get_event_subscriptions.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_event_subscriptions(ip, login_account, login_password):
     """Get event subscriptions

--- a/examples/get_fan_inventory.py
+++ b/examples/get_fan_inventory.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_fan_inventory(ip, login_account, login_password):
     """Get fan inventory

--- a/examples/get_fw_inventory.py
+++ b/examples/get_fw_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_fw_inventory(ip, login_account, login_password):
     """Get BMC inventory    

--- a/examples/get_hostinterface.py
+++ b/examples/get_hostinterface.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_hostinterface(ip, login_account, login_password):
     """Get hostinterface inventory    

--- a/examples/get_memory_inventory.py
+++ b/examples/get_memory_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_memory_inventory(ip, login_account, login_password, system_id, member_id):

--- a/examples/get_metric_definition_report.py
+++ b/examples/get_metric_definition_report.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_metric_definition_report(ip, login_account, login_password):
     """Get metric inventory    

--- a/examples/get_networkprotocol_info.py
+++ b/examples/get_networkprotocol_info.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import traceback
 
 

--- a/examples/get_nic_inventory.py
+++ b/examples/get_nic_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_nic_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_pci_inventory.py
+++ b/examples/get_pci_inventory.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_pci_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_power_limit.py
+++ b/examples/get_power_limit.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_power_limit(ip, login_account, login_password):
     """Get power limit

--- a/examples/get_power_metrics.py
+++ b/examples/get_power_metrics.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_power_metrics(ip, login_account, login_password):
     """Get power metrics

--- a/examples/get_power_redundancy.py
+++ b/examples/get_power_redundancy.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_power_redundancy(ip, login_account, login_password):
     """Get power redundancy

--- a/examples/get_power_state.py
+++ b/examples/get_power_state.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_power_state(ip, login_account, login_password, system_id):

--- a/examples/get_psu_inventory.py
+++ b/examples/get_psu_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_psu_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_schema.py
+++ b/examples/get_schema.py
@@ -23,7 +23,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_schema(ip, login_account, login_password, schema_prefix):
     """Get schema information

--- a/examples/get_secure_boot_status.py
+++ b/examples/get_secure_boot_status.py
@@ -22,7 +22,7 @@
 
 import sys
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import json
 
 

--- a/examples/get_serial_interfaces.py
+++ b/examples/get_serial_interfaces.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_serial_interfaces(ip, login_account, login_password, interfaceid):

--- a/examples/get_server_boot_once.py
+++ b/examples/get_server_boot_once.py
@@ -24,7 +24,7 @@ import sys
 import json
 import redfish
 from redfish import redfish_logger
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_server_boot_once(ip, login_account, login_password, system_id):

--- a/examples/get_server_boot_once_types.py
+++ b/examples/get_server_boot_once_types.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_server_boot_once_types(ip, login_account, login_password, system_id):

--- a/examples/get_sessions.py
+++ b/examples/get_sessions.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_sessions(ip, login_account, login_password):
     """Get BMC inventory    

--- a/examples/get_storage_inventory.py
+++ b/examples/get_storage_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_storage_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_system_inventory.py
+++ b/examples/get_system_inventory.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_system_inventory(ip, login_account, login_password, system_id):

--- a/examples/get_system_log.py
+++ b/examples/get_system_log.py
@@ -24,7 +24,7 @@ import sys
 import redfish
 import json
 import time
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_system_log(ip, login_account, login_password, system_id, type):

--- a/examples/get_system_reset_types.py
+++ b/examples/get_system_reset_types.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_system_reset_types(ip, login_account, login_password, system_id):

--- a/examples/get_temperatures_inventory.py
+++ b/examples/get_temperatures_inventory.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_temperatures_inventory(ip, login_account, login_password):
     """Get temperatures inventory

--- a/examples/get_virtual_media.py
+++ b/examples/get_virtual_media.py
@@ -22,7 +22,7 @@
 import redfish
 import sys
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def get_virtual_media(ip, login_account, login_password):

--- a/examples/get_volt_inventory.py
+++ b/examples/get_volt_inventory.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def get_volt_inventory(ip, login_account, login_password):
     """Get volt inventory

--- a/examples/lenovo_add_alert_recipient.py
+++ b/examples/lenovo_add_alert_recipient.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_add_alert_recipient(ip, login_account, login_password, setting_dict):
     """update bmc user global settings 

--- a/examples/lenovo_bmc_config_backup.py
+++ b/examples/lenovo_bmc_config_backup.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import os
 import time
 

--- a/examples/lenovo_bmc_config_restore.py
+++ b/examples/lenovo_bmc_config_restore.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import os
 import time
 

--- a/examples/lenovo_bmc_license_delete.py
+++ b/examples/lenovo_bmc_license_delete.py
@@ -21,7 +21,7 @@
 
 import sys, os, json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_bmc_license_delete(ip, login_account, login_password, key_id):

--- a/examples/lenovo_bmc_license_export.py
+++ b/examples/lenovo_bmc_license_export.py
@@ -21,7 +21,7 @@
 
 import sys, os, json, struct
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_bmc_license_export(ip, login_account, login_password, license_file):

--- a/examples/lenovo_bmc_license_getinfo.py
+++ b/examples/lenovo_bmc_license_getinfo.py
@@ -21,7 +21,7 @@
 
 import sys, os, json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_bmc_license_getinfo(ip, login_account, login_password):

--- a/examples/lenovo_bmc_license_import.py
+++ b/examples/lenovo_bmc_license_import.py
@@ -21,7 +21,7 @@
 
 import sys, os, json, struct
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_bmc_license_import(ip, login_account, login_password, license_file):

--- a/examples/lenovo_create_bmc_user.py
+++ b/examples/lenovo_create_bmc_user.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 #set user privileges
 def set_custom_role_privileges(REDFISH_OBJ,response_account_service_url,roleid,authority):

--- a/examples/lenovo_create_raid_volume.py
+++ b/examples/lenovo_create_raid_volume.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_create_raid_volume(ip, login_account, login_password, system_id, raidid, volume_name, raid_type, volume_capacity, read_policy, write_policy, io_policy, access_policy, drive_cache_policy):

--- a/examples/lenovo_del_alert_recipient.py
+++ b/examples/lenovo_del_alert_recipient.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_del_alert_recipient(ip, login_account, login_password, index_id):
     """delete bmc alert recipient

--- a/examples/lenovo_delete_bmc_user.py
+++ b/examples/lenovo_delete_bmc_user.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_delete_bmc_user(ip, login_account, login_password, username):

--- a/examples/lenovo_delete_raid_volume.py
+++ b/examples/lenovo_delete_raid_volume.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_delete_raid_volume(ip, login_account, login_password, system_id, raidid, volume_name):

--- a/examples/lenovo_eklm_certificate_generate_csr.py
+++ b/examples/lenovo_eklm_certificate_generate_csr.py
@@ -30,7 +30,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_eklm_certificate_generate_csr(ip, login_account, login_password, Country, StateOrProvince, Locality, Organization, HostName):

--- a/examples/lenovo_eklm_certificate_import.py
+++ b/examples/lenovo_eklm_certificate_import.py
@@ -30,7 +30,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_eklm_certificate_import(ip, login_account, login_password, certtype, certfile):

--- a/examples/lenovo_eklm_keyserver_config.py
+++ b/examples/lenovo_eklm_keyserver_config.py
@@ -30,7 +30,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_eklm_keyserver_config(ip, login_account, login_password, kmprotocol, kmhostname, kmport, kmgroup):

--- a/examples/lenovo_eklm_keyserver_getinfo.py
+++ b/examples/lenovo_eklm_keyserver_getinfo.py
@@ -30,7 +30,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_eklm_keyserver_getinfo(ip, login_account, login_password):

--- a/examples/lenovo_export_ffdc_data.py
+++ b/examples/lenovo_export_ffdc_data.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import time
 import os
 

--- a/examples/lenovo_get_alert_recipients.py
+++ b/examples/lenovo_get_alert_recipients.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_get_alert_recipients(ip, login_account, login_password):
     """get bmc alert recipients 

--- a/examples/lenovo_get_bios_boot_order.py
+++ b/examples/lenovo_get_bios_boot_order.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_get_bios_boot_order(ip, login_account, login_password, system_id):

--- a/examples/lenovo_get_bmc_external_ldap.py
+++ b/examples/lenovo_get_bmc_external_ldap.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_get_bmc_external_ldap(ip, login_account, login_password):

--- a/examples/lenovo_get_bmc_user_accounts.py
+++ b/examples/lenovo_get_bmc_user_accounts.py
@@ -24,7 +24,7 @@ import sys
 import logging
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 from collections import OrderedDict
 
 

--- a/examples/lenovo_get_bmc_user_global.py
+++ b/examples/lenovo_get_bmc_user_global.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_get_bmc_user_global(ip, login_account, login_password):
     """get bmc user global settings 

--- a/examples/lenovo_get_bmc_user_ldap_policy.py
+++ b/examples/lenovo_get_bmc_user_ldap_policy.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import traceback
 
 def lenovo_get_bmc_user_ldap_policy(ip, login_account, login_password):

--- a/examples/lenovo_get_cpu_inventory.py
+++ b/examples/lenovo_get_cpu_inventory.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_get_cpu_inventory(ip, login_account, login_password, system_id, member_id):

--- a/examples/lenovo_get_ssh_pubkey.py
+++ b/examples/lenovo_get_ssh_pubkey.py
@@ -24,7 +24,7 @@ import sys
 import logging
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_get_ssh_pubkey(ip, login_account, login_password, user_name):

--- a/examples/lenovo_import_ssh_pubkey.py
+++ b/examples/lenovo_import_ssh_pubkey.py
@@ -24,7 +24,7 @@ import sys
 import logging
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_import_ssh_pubkey(ip, login_account, login_password, user_name, pb_command):

--- a/examples/lenovo_ldap_certificate_add.py
+++ b/examples/lenovo_ldap_certificate_add.py
@@ -22,7 +22,7 @@
 import sys, os, struct
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ldap_certificate_add(ip, login_account, login_password, certfile):

--- a/examples/lenovo_ldap_certificate_disable.py
+++ b/examples/lenovo_ldap_certificate_disable.py
@@ -22,7 +22,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ldap_certificate_disable(ip, login_account, login_password):

--- a/examples/lenovo_ldap_certificate_enable.py
+++ b/examples/lenovo_ldap_certificate_enable.py
@@ -22,7 +22,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ldap_certificate_enable(ip, login_account, login_password):

--- a/examples/lenovo_mount_virtual_media.py
+++ b/examples/lenovo_mount_virtual_media.py
@@ -24,7 +24,7 @@ import sys
 import redfish
 import json
 import time
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_mount_virtual_media(ip, login_account, login_password, image, mounttype, fsprotocol, fsip, fsport, fsusername, fspassword, fsdir, readonly, domain, options, inserted, writeprotocol):

--- a/examples/lenovo_set_bios_boot_order.py
+++ b/examples/lenovo_set_bios_boot_order.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_set_bios_boot_order(ip, login_account, login_password, system_id, bootorder):

--- a/examples/lenovo_set_bmc_config_default.py
+++ b/examples/lenovo_set_bmc_config_default.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_set_bmc_config_default(ip, login_account, login_password):
     """set BMC configuration default

--- a/examples/lenovo_set_bmc_dns.py
+++ b/examples/lenovo_set_bmc_dns.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_set_bmc_dns(ip, login_account, login_password, enabled, dnsserver):

--- a/examples/lenovo_set_bmc_external_ldap.py
+++ b/examples/lenovo_set_bmc_external_ldap.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import traceback
 
 

--- a/examples/lenovo_set_bmc_user_global.py
+++ b/examples/lenovo_set_bmc_user_global.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def lenovo_set_bmc_user_global(ip, login_account, login_password, setting_dict):
     """update bmc user global settings 

--- a/examples/lenovo_set_bmc_user_ldap_policy.py
+++ b/examples/lenovo_set_bmc_user_ldap_policy.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import traceback
 
 def lenovo_set_bmc_user_ldap_policy(ip, login_account, login_password, policy):

--- a/examples/lenovo_set_serial_interfaces.py
+++ b/examples/lenovo_set_serial_interfaces.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_set_serial_interfaces(ip, login_account, login_password, interfaceid, bitrate, stopbits, parity, enabled, climode, state, clikey):

--- a/examples/lenovo_ssl_certificate_generate_csr.py
+++ b/examples/lenovo_ssl_certificate_generate_csr.py
@@ -22,7 +22,7 @@
 import sys, os, struct
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ssl_certificate_generate_csr(ip, login_account, login_password, format, Country, StateOrProvince, Locality, Organization, HostName):

--- a/examples/lenovo_ssl_certificate_getinfo.py
+++ b/examples/lenovo_ssl_certificate_getinfo.py
@@ -22,7 +22,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ssl_certificate_getinfo(ip, login_account, login_password):

--- a/examples/lenovo_ssl_certificate_import.py
+++ b/examples/lenovo_ssl_certificate_import.py
@@ -22,7 +22,7 @@
 import sys, os, struct
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_ssl_certificate_import(ip, login_account, login_password, certfile):

--- a/examples/lenovo_umount_virtual_media.py
+++ b/examples/lenovo_umount_virtual_media.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_umount_virtual_media(ip, login_account, login_password, image, mounttype):

--- a/examples/lenovo_update_firmware.py
+++ b/examples/lenovo_update_firmware.py
@@ -26,7 +26,7 @@ import sys
 import redfish
 import json
 import update_firmware
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import requests
 import time
 from requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/examples/lenovo_update_raid_volume.py
+++ b/examples/lenovo_update_raid_volume.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def lenovo_update_raid_volume(ip, login_account, login_password, system_id, raidid, volume_name, read_policy, write_policy, io_policy, access_policy, drive_cache_policy):

--- a/examples/manage_inventory.py
+++ b/examples/manage_inventory.py
@@ -23,7 +23,7 @@
 import sys, os
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def create_parameter(supported_subcmd_list):

--- a/examples/mount_virtual_media.py
+++ b/examples/mount_virtual_media.py
@@ -33,7 +33,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def mount_virtual_media(ip, login_account, login_password, fsprotocol, fsip, fsport, image, fsdir, inserted, writeprotocol):

--- a/examples/reset_bios_default.py
+++ b/examples/reset_bios_default.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def reset_bios_default(ip, login_account, login_password, system_id):

--- a/examples/reset_secure_boot.py
+++ b/examples/reset_secure_boot.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def reset_secure_boot(ip, login_account, login_password, system_id, reset_keys_type):

--- a/examples/restart_bmc.py
+++ b/examples/restart_bmc.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def restart_bmc(ip, login_account, login_password):
     """Get restart manager result    

--- a/examples/send_test_event.py
+++ b/examples/send_test_event.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import datetime
 
 def send_test_event(ip, login_account, login_password,eventid,message,severity):

--- a/examples/send_test_metric.py
+++ b/examples/send_test_metric.py
@@ -24,7 +24,7 @@ import sys
 import redfish
 import json
 import datetime
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def send_test_metric(ip, login_account, login_password, reportname):
     """Send Test Metric

--- a/examples/set_bios_attribute.py
+++ b/examples/set_bios_attribute.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bios_attribute(ip, login_account, login_password, system_id, attribute_name, attribute_value):

--- a/examples/set_bios_bootmode_legacy.py
+++ b/examples/set_bios_bootmode_legacy.py
@@ -22,7 +22,7 @@
 
 import json, sys
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bios_bootmode_legacy(ip, login_account, login_password, system_id):

--- a/examples/set_bios_bootmode_uefi.py
+++ b/examples/set_bios_bootmode_uefi.py
@@ -22,7 +22,7 @@
 
 import json, sys
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bios_bootmode_uefi(ip, login_account, login_password, system_id):

--- a/examples/set_bios_password.py
+++ b/examples/set_bios_password.py
@@ -24,7 +24,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bios_password(ip, login_account, login_password, system_id, bios_password_name, bios_password, oldbiospass):

--- a/examples/set_bmc_ipv4.py
+++ b/examples/set_bmc_ipv4.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bmc_ipv4(ip, login_account, login_password, dhcp_enabled, static_ip, static_gateway, static_mask):

--- a/examples/set_bmc_ntp.py
+++ b/examples/set_bmc_ntp.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bmc_ntp(ip, login_account, login_password, ntp_server, ProtocolEnabled):

--- a/examples/set_bmc_timezone.py
+++ b/examples/set_bmc_timezone.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bmc_timezone(ip, login_account, login_password, timezone):

--- a/examples/set_bmc_vlanid.py
+++ b/examples/set_bmc_vlanid.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_bmc_vlanid(ip, login_account, login_password, vlanid, vlanEnable):

--- a/examples/set_chassis_indicator_led.py
+++ b/examples/set_chassis_indicator_led.py
@@ -22,7 +22,7 @@
 import redfish
 import sys
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_chassis_indicator_led(ip, login_account, login_password, led_status):

--- a/examples/set_networkprotocol.py
+++ b/examples/set_networkprotocol.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 import traceback
 
 def set_networkprotocol(ip, login_account, login_password, service, enabled, port):

--- a/examples/set_power_limit.py
+++ b/examples/set_power_limit.py
@@ -22,7 +22,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_power_limit(ip, login_account, login_password, isenable, power_limit):

--- a/examples/set_power_state.py
+++ b/examples/set_power_state.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_power_state(ip, login_account, login_password, system_id, reset_type):

--- a/examples/set_serial_interfaces.py
+++ b/examples/set_serial_interfaces.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_serial_interfaces(ip, login_account, login_password, interfaceid, bitrate, stopbits, parity, enabled):

--- a/examples/set_server_asset_tag.py
+++ b/examples/set_server_asset_tag.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_server_asset_tag(ip, login_account, login_password, system_id, asset_tag):

--- a/examples/set_server_boot_once.py
+++ b/examples/set_server_boot_once.py
@@ -23,7 +23,7 @@
 import sys
 import json
 import redfish
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def set_server_boot_once(ip, login_account, login_password, system_id, boot_source, mode):

--- a/examples/umount_virtual_media.py
+++ b/examples/umount_virtual_media.py
@@ -34,7 +34,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def umount_virtual_media(ip, login_account, login_password, image):

--- a/examples/update_bmc_user_password.py
+++ b/examples/update_bmc_user_password.py
@@ -23,7 +23,7 @@
 import sys
 import redfish
 import json
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 def update_bmc_user_password(ip, login_account, login_password, username, new_password):
     """update user password    

--- a/examples/update_firmware.py
+++ b/examples/update_firmware.py
@@ -27,7 +27,7 @@ from requests.auth import HTTPBasicAuth
 import redfish
 import json
 import time
-import lenovo_utils as utils
+from . import lenovo_utils as utils
 
 
 def update_firmware(ip, login_account, login_password, image, targets, fsprotocol, fsip, fsport, fsusername, fspassword, fsdir):


### PR DESCRIPTION
…of folder

This way, one can write custom scripts that aren't located inside the example folder and only include the examples.

It would be great to have the examples as a library as they cover a nice set of features and abstract the redfish API even further.