### PR TITLE
Update the method used to delete bmc user

### DIFF
--- a/examples/lenovo_delete_bmc_user.py
+++ b/examples/lenovo_delete_bmc_user.py
@@ -118,7 +118,7 @@ def lenovo_delete_bmc_user(ip, login_account, login_password, username):
         
         # Check user delete mode
         delete_mode = "DELETE_Action"
-        if response_accounts_url.dict["Members@odata.count"] in [9, 12]:
+        if "DELETE" not in response_account_url.getheader("Allow"):
             delete_mode = "PATCH_Action"
             
         if delete_mode == "DELETE_Action":


### PR DESCRIPTION
When deleting a user, the DELETE or PATCH method is determined by the value of the "Allow" attribute in the response header.
If the value of "Allow"  contains DELETE , the DELETE method is used, otherwise the PATCHmethod is used.